### PR TITLE
Prevent Jenkins library version conflict

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('defra-library@4')
+@Library('defra-library@4.13')
 import uk.gov.defra.ffc.DefraUtils
 def defraUtils = new DefraUtils()
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-elm-scheme-service",
   "description": "",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "homepage": "https://github.com/DEFRA/ffc-elm-scheme-service",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Set minor version of Jenkins library so the version can't match git
revisions as well as the version tag.