### PR TITLE
Revert DefraUtils to v4 tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('defra-library@4.13')
+@Library('defra-library@4')
 import uk.gov.defra.ffc.DefraUtils
 def defraUtils = new DefraUtils()
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-elm-scheme-service",
   "description": "",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "homepage": "https://github.com/DEFRA/ffc-elm-scheme-service",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The issue with this tag has been addressed. The 4.13 tag is out of date
but there is no 4.14 tag due to issues with the release process for
DefraUtils.