### PR TITLE
Remove PR cleanup from build pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,11 +134,6 @@ node {
         }
       }
     }
-    if (mergedPrNo != '') {
-      stage('Remove merged PR') {
-        defraUtils.undeployChart(KUBE_CREDENTIALS_ID, serviceName, mergedPrNo)
-      }
-    }
     stage('Set GitHub status as success'){
       defraUtils.setGithubStatusSuccess()
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ def pr = ''
 def prPlanCommandQueueName = 'plan-command'
 def prPostgresDatabaseName = 'ffc_elm_scheme'
 def prPostgresExternalNameCredId = 'ffc-elm-postgres-external-name-pr'
-def prPostgresUserCredId = 'ffc-elm-postgres-user-jenkins'
+def jenkinsPostgresUserCredId = 'ffc-elm-postgres-user-jenkins'
 def prSqsQueuePrefix = 'devffc-elm-scheme-service'
 def serviceName = 'ffc-elm-scheme-service'
 def serviceNamespace = 'ffc-elm'
@@ -64,7 +64,7 @@ node {
     }
     if (pr != '') {
       stage('Provision PR infrastructure') {
-        defraUtils.provisionPrDatabaseRoleAndSchema(prPostgresExternalNameCredId, prPostgresDatabaseName, prPostgresUserCredId, 'ffc-elm-scheme-service-postgres-user-pr', pr, true)
+        defraUtils.provisionPrDatabaseRoleAndSchema(prPostgresExternalNameCredId, prPostgresDatabaseName, jenkinsPostgresUserCredId, 'ffc-elm-scheme-service-postgres-user-pr', pr, true)
         defraUtils.provisionPrSqsQueue(prSqsQueuePrefix, pr, prPlanCommandQueueName, "ELM", "ELM", "Environmental Land Management")
       }
       stage('Helm install') {
@@ -72,7 +72,7 @@ node {
           string(credentialsId: 'ffc-elm-scheme-service-role-arn', variable: 'serviceAccountRoleArn'),
           string(credentialsId: 'ffc-elm-sqs-plan-command-queue-endpoint-pr', variable: 'planCommandQueueEndpoint'),
           string(credentialsId: prPostgresExternalNameCredId, variable: 'postgresExternalName'),
-          usernamePassword(credentialsId: prPostgresUserCredId, usernameVariable: 'postgresUsername', passwordVariable: 'postgresPassword')
+          usernamePassword(credentialsId: jenkinsPostgresUserCredId, usernameVariable: 'postgresUsername', passwordVariable: 'postgresPassword')
         ]) {
           def helmValues = [
             /deployment.redeployOnChange="${pr}-${BUILD_NUMBER}"/,
@@ -137,10 +137,6 @@ node {
     if (mergedPrNo != '') {
       stage('Remove merged PR') {
         defraUtils.undeployChart(KUBE_CREDENTIALS_ID, serviceName, mergedPrNo)
-      }
-      stage('Remove PR infrastructure') {
-        defraUtils.destroyPrDatabaseRoleAndSchema(prPostgresExternalNameCredId, prPostgresDatabaseName, prPostgresUserCredId, pr)
-        defraUtils.destroyPrSqsQueues(prSqsQueuePrefix, pr)
       }
     }
     stage('Set GitHub status as success'){

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-elm-scheme-service",
   "description": "",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "homepage": "https://github.com/DEFRA/ffc-elm-scheme-service",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/ELM-1638

PR resource cleanup has moved to a separate pipeline, triggered automatically on merge via Jenkins action triggers (configured in the Jenkins UI).